### PR TITLE
Improve dev onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,26 @@ Clone of Uniswap V2 to Cairo. AMM for StarkNet.
 
 ## Testing and Development
 
-### Dependencies
-* [protostar](https://docs.swmansion.com/protostar/)
+We use [Protostar](https://docs.swmansion.com/protostar/) for our testing and development purposes. 
+Protostar is a StarkNet smart contract development toolchain, which helps you with dependencies management, compiling and testing cairo contracts.
+### Install Protostar
 
-    To install protostar dependencies:
-    ```
-    protostar install
-    ```
+
+1. Copy and run in a terminal the following command:
+```
+curl -L https://raw.githubusercontent.com/software-mansion/protostar/master/install.sh | bash
+```
+2. Restart the terminal.
+3. Run `protostar -v` to check Protostar and cairo-lang version.
+
+#### Note 
+Protostar requires version 2.28 or greater of Git.
+
+
+### Install Protostar Dependencies
+```
+protostar install
+```
 
 ### Compile Contracts
 ```
@@ -18,19 +31,31 @@ protostar build
 ```
 
 ### Run Tests
-
-To run protostar tests:
 ```
 protostar test
 ```
 
 ### Run Scripts
 
-#### Additional Dependencies
 
-* [python3.8](https://www.python.org/downloads/release/python-3813/)
+#### Setup a local virtual env
+
+```
+python -m venv ./venv
+source ./venv/bin/activate
+```
+
+#### Install dependencies
+```
+pip install -r requirements.txt
+```
+
+Find more info about the installed dependencies here:
 * [starknet-devnet](https://github.com/Shard-Labs/starknet-devnet)
 * [starknet.py](https://github.com/software-mansion/starknet.py)
+
+
+#### Run Scripts
 
 All scripts are placed in ```scripts``` folder. testnet config is not committed, please create your own in ```scripts/config```
 
@@ -39,7 +64,7 @@ To run scripts on local system, you first need to run a devnet server:
 starknet-devnet
 ```
 
-Example:
+Run script by specifying the path to the script file. Example:
 ```
 python scripts/deploy.py local
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+cairo-lang==0.9.0
+cairo-nile==0.6.1
+openzeppelin-cairo-contracts==0.2.1
+pytest-asyncio==0.18.3
+pytest==7.1.2
+pytest-xdist==2.5.0
+starknet.py==0.4.0-alpha
+starknet-devnet==0.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,5 @@
-cairo-lang==0.9.0
-cairo-nile==0.6.1
-openzeppelin-cairo-contracts==0.2.1
-pytest-asyncio==0.18.3
-pytest==7.1.2
-pytest-xdist==2.5.0
-starknet.py==0.4.0-alpha
-starknet-devnet==0.2.4
+# cairo-lang==0.9.0
+# cairo-nile==0.6.1
+# openzeppelin-cairo-contracts==0.2.1
+starknet.py>=0.4.0-alpha
+starknet-devnet>=0.2.4


### PR DESCRIPTION
Added Protostar installation guidelines to README so that the dev has access to all the commands they need to run to get started with our repo at the same place.

Added commands to set up a local virtual env in README which installs all dependencies listed in the new requirements.txt file. New Devs can follow the README and execute listed commands to get started with development.